### PR TITLE
enable to delete next page on delete_item_occurrences.py

### DIFF
--- a/delete_item_occurrences.py
+++ b/delete_item_occurrences.py
@@ -45,7 +45,7 @@ def get_item_id(rollbar_item_counter):
 # Pull list of all occurrences in the item
 # _______________________________________________________________
 def delete_occurrences(item_id):
-    url = 'https://api.rollbar.com/api/1/item/' + str(item_id) + '/instances'
+    url = 'https://api.rollbar.com/api/1/item/' + str(item_id) + '/instances?limit=5000'
 
     headers = {
         'X-Rollbar-Access-Token': project_read_token
@@ -59,6 +59,10 @@ def delete_occurrences(item_id):
     # Parse the response to loop through the occurrence IDs
     response_data = response.json()
 
+    # If there are no occurrences, stop the execution
+    if response_data['result']['instances'] == []:
+        return
+
     for i in response_data['result']['instances']:
         occurrence_id = i['id']
 
@@ -70,8 +74,14 @@ def delete_occurrences(item_id):
         payload = {}
 
         response = requests.request('DELETE', url, headers = headers, data = payload)
-        print('Deleted Occurrence ID: ' + str(occurrence_id))
+        status = response.status_code
+        if status == 200:
+            print('Deleted Occurrence ID: ' + str(occurrence_id))
+        else:
+            print('Deletion is failed. Occurrence ID: ' + str(occurrence_id))
 
+    # call next page
+    delete_occurrences(item_id)
 
 # _______________________________________________________________
 # Running the functions above


### PR DESCRIPTION
According to [List all occurrences in an item](https://docs.rollbar.com/reference/get_api-1-item-item-id-instances), he default number of elements returned per page is 20. So if we'd like to delete 100 occurrences we execute this script 5 times.

This PR provide to delete all occurrences in the item truly.